### PR TITLE
Webpack honours build type when publishing from Visual Studio

### DIFF
--- a/AureliaDotnetTemplate.csproj
+++ b/AureliaDotnetTemplate.csproj
@@ -28,8 +28,23 @@
 		<Exec Command="npm run webpack:dev" />
 	</Target>
 
-	<Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
-		<!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
+	<Target Name="PublishRunWebpackDebug" AfterTargets="ComputeFilesToPublish" Condition=" '$(Configuration)' == 'Debug'">
+		<!-- As part of publishing, ensure the JS resources are freshly built in DEVELOPMENT mode for Debug builds -->
+		<Exec Command="npm install" />
+		<Exec Command="npm run webpack:dev" />
+
+		<!-- Include the newly-built files in the publish output -->
+		<ItemGroup>
+			<DistFiles Include="wwwroot\dist\**" />
+			<ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+				<RelativePath>%(DistFiles.Identity)</RelativePath>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			</ResolvedFileToPublish>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="PublishRunWebpackRelease" AfterTargets="ComputeFilesToPublish" Condition=" '$(Configuration)' == 'Release'">
+		<!-- As part of publishing, ensure the JS resources are freshly built in production mode for release builds -->
 		<Exec Command="npm install" />
 		<Exec Command="npm run webpack:prod" />
 

--- a/AureliaDotnetTemplate.csproj
+++ b/AureliaDotnetTemplate.csproj
@@ -1,61 +1,47 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-	<PropertyGroup>
-		<TargetFramework>netcoreapp2.1</TargetFramework>
-		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-		<TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+    <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
-	</ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
+  </ItemGroup>
 
-	<Target Name="DebugRunWebpack" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('wwwroot\dist') ">
-		<!-- Ensure Node.js is installed -->
-		<Exec Command="node --version" ContinueOnError="true">
-			<Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
-		</Exec>
-		<Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
+  <Target Name="DebugRunWebpack" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('wwwroot\dist') ">
+    <!-- Ensure Node.js is installed -->
+    <Exec Command="node --version" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
+    </Exec>
+    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
 
-		<!-- In development, the dist files won't exist on the first run or when cloning to
+    <!-- In development, the dist files won't exist on the first run or when cloning to
 				 a different machine, so rebuild them if not already present. -->
-		<Message Importance="high" Text="Performing first-run Webpack build..." />
-		<Exec Command="npm run webpack:dev" />
-	</Target>
+    <Message Importance="high" Text="Performing first-run Webpack build..." />
+    <Exec Command="npm run webpack:dev" />
+  </Target>
 
-	<Target Name="PublishRunWebpackDebug" AfterTargets="ComputeFilesToPublish" Condition=" '$(Configuration)' == 'Debug'">
-		<!-- As part of publishing, ensure the JS resources are freshly built in DEVELOPMENT mode for Debug builds -->
-		<Exec Command="npm install" />
-		<Exec Command="npm run webpack:dev" />
-
-		<!-- Include the newly-built files in the publish output -->
-		<ItemGroup>
-			<DistFiles Include="wwwroot\dist\**" />
-			<ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-				<RelativePath>%(DistFiles.Identity)</RelativePath>
-				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-			</ResolvedFileToPublish>
-		</ItemGroup>
-	</Target>
-
-	<Target Name="PublishRunWebpackRelease" AfterTargets="ComputeFilesToPublish" Condition=" '$(Configuration)' == 'Release'">
-		<!-- As part of publishing, ensure the JS resources are freshly built in production mode for release builds -->
-		<Exec Command="npm install" />
-		<Exec Command="npm run webpack:prod" />
-
-		<!-- Include the newly-built files in the publish output -->
-		<ItemGroup>
-			<DistFiles Include="wwwroot\dist\**" />
-			<ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-				<RelativePath>%(DistFiles.Identity)</RelativePath>
-				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-			</ResolvedFileToPublish>
-		</ItemGroup>
-	</Target>
+  <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
+    <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
+    <Exec Command="npm install" />
+    <Exec Command="npm run webpack:dev" Condition="'$(Configuration)' == 'Debug'" />
+    <Exec Command="npm run webpack:prod" Condition="'$(Configuration)' == 'Release'" />
+    
+    <!-- Include the newly-built files in the publish output -->
+    <ItemGroup>
+      <DistFiles Include="wwwroot\dist\**" />
+      <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+        <RelativePath>%(DistFiles.Identity)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
As you are probably aware, Visual Studio can "Publish" which does a build and then uses msdeploy to put the output onto a webserver. It is possible to specify the build type (release or debug) interactively, and publishing respects this setting and produces appropriate binaries and any supporting resources.

Compilation and bundling is done by MSBUILD according to the content of the CSPROJ file. Unfortunately, whoever wrote the build target responsible for using Webpack failed to consider the type of build.

This change corrects this omission, specifying a dev flag to webpack when publishing a debug build, and a prod flag for release builds.
